### PR TITLE
quick pass at FAQ on landing page, fix contact form using Formspree

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -122,18 +122,18 @@ weight = 2
 
 # footer menu
 [[Languages.en.menu.footer]]
-name = "Releases"
-url = "releases"
+name = "Installation"
+url = "overview/installation/"
 weight = 1
 
 [[Languages.en.menu.footer]]
-name = "contact"
+name = "Contact"
 url = "contact"
 weight = 2
 
 [[Languages.en.menu.footer]]
 name = "Github"
-url = "https://github.com/themefisher/"
+url = "https://github.com/wasmcloud/"
 weight = 3
 
 
@@ -147,7 +147,7 @@ weight = 1
 
 [[Languages.fr.menu.main]]
 name = "Github"
-url = "https://github.com/themefisher/"
+url = "https://github.com/wasmcloud/"
 weight = 2
 
 
@@ -164,7 +164,7 @@ weight = 2
 
 [[Languages.fr.menu.footer]]
 name = "Github"
-url = "https://github.com/themefisher/"
+url = "https://github.com/wasmcloud/"
 weight = 3
 
 #################### default parameters ################################
@@ -172,9 +172,9 @@ weight = 3
 logo = "images/logo.png"
 # Meta data
 description = "This is meta description"
-author = "Themefisher"
+author = "wasmCloud LLC"
 # contact form action
-contact_form_action = "#" # contact form works with https://formspree.io
+contact_form_action = "https://formspree.io/f/mvovydey" # contact form works with https://formspree.io
 
 # Preloader
 [params.preloader]
@@ -197,7 +197,7 @@ link = "contact"
 #[[params.social]]
 #title = "facebook"
 #icon = "ti-facebook" # themify icon : https://themify.me/themify-icons
-#link = "#"
+#link = "https://www.facebook.com/WasmCloud-102542298375661/"
 
 [[params.social]]
 title = "twitter"
@@ -212,7 +212,7 @@ link = "https://github.com/wasmCloud"
 #[[params.social]]
 #title = "linkedin"
 #icon = "ti-linkedin" # themify icon : https://themify.me/themify-icons
-#link = "#"
+#link = "https://www.linkedin.com/company/wasmCloud"
 
 
 ################################### English language #####################################
@@ -253,8 +253,8 @@ copyright = "Copyright &copy; 2021 wasmCloud LLC"
 
 # banner
 [Languages.fr.banner]
-title = "Documentation Theme By Themefisher Team"
-subtitle = "Lorem ipsum dolor amet, consetetur sadiffspscing elitr, diam nonumy invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua At."
+title = "wasmCloud Developer Documentation"
+subtitle = "Build|Run|Deploy|Scale microservices quickly."
 image = "images/banner.jpg"
 
 # call to action

--- a/content/faq/index.en.md
+++ b/content/faq/index.en.md
@@ -1,17 +1,33 @@
 ---
 title: "Frequently Asked Questions"
 description: "FAQ"
+weight: 6
 draft: false
 ---
-
+ 
+{{< faq "What is wasmCloud?" >}}
+wasmCloud helps developers build, test, scale, deploy and operate microservices at scale *quickly*.
+ 
+wasmCloud is an application runtime that has been designed to speed up the developer workflow.  An actor model seamlessly separates business logic from specific underlying capabilities.  Common capabilities are included in the runtime and developers may easily create and sign their own.  Wasm allows developers to write their microservices once in the language of their choice and deploy them everywhere.  There is a lot more, please watch for a quickstart, coming soon.
+{{</ faq >}}
+ 
+ 
 {{< faq "Why WebAssembly?" >}}
-Lorem, [link](https://examplesite.com) _ipsum_ dolor sit amet consectetur adipisicing elit. Cumque praesentium nisi officiis maiores quia sapiente totam omnis vel sequi corporis ipsa incidunt reprehenderit recusandae maxime perspiciatis iste placeat architecto, mollitia delectus ut ab quibusdam. Magnam cumque numquam tempore reprehenderit illo, unde cum omnis vel sed temporibus. mollitia delectus ut ab quibusdam. Magnam cumque numquam tempore reprehenderit illo, unde cum omnis vel sed temporibus. mollitia delectus ut ab quibusdam. Magnam cumque numquam tempore reprehenderit illo, unde cum omnis vel sed temporibus.
+WebAssembly (Wasm) is a highly portable binary instruction format for a stack-based virtual machine.  Wasm is designed as a portable and performant compilation target for programming languages enabling secure deny-by-default deployment on the web, in the browser, on your server, the edge, or where ever you would like to run your workload.
+ 
+wasmCloud leverages Wasm as a secure and portable deployment layer - write your function quickly and run them everywhere.  Wasm is not only fast - it's efficient.
 {{</ faq >}}
-
+ 
 {{< faq "What is an actor?" >}}
-Lorem, ipsum dolor sit amet consectetur adipisicing elit. Cumque praesentium nisi officiis maiores quia sapiente totam omnis vel sequi corporis ipsa incidunt reprehenderit recusandae maxime perspiciatis iste placeat architecto.
+An actor is the smallest unit of deployable, portable compute within the wasmCloud ecosystem. Actors are small WebAssembly modules that can handle messages delivered to them by the host runtime and can invoke functions on [capability providers](reference/host-runtime/capabilities), provided they have been [granted the appropriate privileges](reference/host-runtime/security/).
+ 
+For more information please see [Actors Reference Guide](reference/host-runtime/actors/).
 {{</ faq >}}
-
-{{< faq "Will it game?" >}}
-Lorem, ipsum dolor sit amet consectetur adipisicing elit. Cumque praesentium nisi officiis maiores quia sapiente totam omnis vel sequi corporis ipsa incidunt reprehenderit recusandae maxime perspiciatis iste placeat architecto, mollitia delectus [link](https://examplesite.com) ut ab quibusdam. Magnam cumque numquam tempore reprehenderit illo, unde cum omnis vel sed temporibus, repudiandae impedit nam ad enim porro, qui labore fugiat quod suscipit fuga necessitatibus. Perferendis, ipsum?
+ 
+{{< faq "what is a capability provider?" >}}
+A capability is an abstraction or representation of a non-functional requirement; some functionality required by your [actor](reference/host-runtime/actors/) that is not considered part of the core business logic. For example, as you write an actor that exposes some data over a RESTful endpoint, the HTTP server is not part of your business logic, it is a service used by your actor–a capability.
+ 
+In wasmCloud, capability providers are dynamic libraries that implement a capability contract. A capability contract is a unique name that identifies the interface or abstraction. By convention, these capability contract IDs are prefixed by a vendor ID (the vendor of the contract, not necessarily the specific implementation).
+ 
+For more information please see [Capabilities Reference Guide](http://localhost:1313/reference/host-runtime/capabilities/).
 {{</ faq >}}


### PR DESCRIPTION
This pull requests:

-  cleans up the landing page a little bit by adding four basic FAQs
- removing the lorem ipsem from home page
- fixes a few of the links in the footer and the header
- enables the contact form from the using formspree
