### PR TITLE
Ensure no more than one code copy button is added

### DIFF
--- a/themes/godocs-1/assets/js/script.js
+++ b/themes/godocs-1/assets/js/script.js
@@ -125,7 +125,10 @@ $(document).on("turbolinks:load", preloader);
 				});
 				clipInit = true;
 			}
-			code.after('<span class="copy-to-clipboard">copy</span>');
+			// prevents multiple spans from being appended to code blocks
+			if (!Array.from(code[0].parentElement.children).reduce((acc, elem) => acc || elem instanceof HTMLSpanElement, false)) {
+				code.after('<span class="copy-to-clipboard">copy</span>');
+			}
 		}
 	});
 	$('.copy-to-clipboard').click(function () {


### PR DESCRIPTION
Fixes #24 

It's been a while since I've gotten to write some JavaScript!

I explored a few different methods to solving this issue, it does appear that the root cause is the fact that this script is being loaded in the `footer` element of the DOM. Unfortunately this ends up getting executed every time the page changes, ([this source](https://github.com/turbolinks/turbolinks#working-with-script-elements) recommends loading the turbolinks script in the head, which is normal). After a while of trying and failing to understand how all of this template links together, I settled on a functional approach to ensuring that only one `copy` element is added to the page at a time.

This fix does require a fairly quick computation, but you'll notice the array size of the codeblock never exceeds 2, so the `reduce` will be essentially `O(1)` each run. It works by grabbing the parent element of the code block and ensuring that that parent does not already have the copy `span` element. If it doesn't have it, then we append the `span` element after the codeblock in the DOM, which becomes a child of the parent.