### PR TITLE
Updated release notes for 0.16.0 and 0.17.0

### DIFF
--- a/content/releases/index.en.md
+++ b/content/releases/index.en.md
@@ -1,9 +1,40 @@
 ---
-title: "Release History"
+title: "Release History / Changelog"
 description: "This is a high-level overview of the additions, removals, and changes for releases of wasmcloud and related tooling. This is not a complete list. For all of the specific details, check out the release notes for each release in the appropriate repository."
 layout: "changelog"
 draft: false
 ---
+
+### Release 0.17.0
+{{< changelog "added" >}}
+* Added additional logging and error messages to common operations ([PR #143](https://github.com/wasmCloud/wasmCloud/pull/143) and [PR #148](https://github.com/wasmCloud/wasmCloud/pull/148))
+* Added the ability to remove a link on the Host API and control interface ([PR #147](https://github.com/wasmCloud/wasmCloud/pull/147))
+* Added extensive Rust documentation on the `wasmcloud_host` crate ([PR #151](https://github.com/wasmCloud/wasmCloud/pull/151))
+* Added additional queries to the Host API to query the lattice cache. This allows users directly invoking the Host API to retrieve the same information available via the control interface ([PR #153](https://github.com/wasmCloud/wasmCloud/pull/153))
+{{</ changelog >}}
+
+{{< changelog "Fixed" >}}
+* Fixed an issue where operations could be called on a host that had not started ([PR #142](https://github.com/wasmCloud/wasmCloud/pull/142))
+{{</ changelog >}}
+
+### Release 0.16.0
+The **0.16.0** release includes multiple bug fixes, documentation improvements, and additional features.
+
+{{< changelog "added" >}}
+* Added `bencher` sample for determining wasmcloud performance ([PR #100](https://github.com/wasmCloud/wasmCloud/pull/100))
+{{</ changelog >}}
+
+{{< changelog "changed" >}}
+* Renamed `wascc-codec` to `wasmcloud-provider-core` ([PR #102](https://github.com/wasmCloud/wasmCloud/pull/102))
+* Updated embedded Extras provider to use `wasmcloud:extras` capability contract ([PR #109](https://github.com/wasmCloud/wasmCloud/pull/109))
+* Updated `actix-rt` to `2.1.0` which is based on `tokio 1.X`. This is a breaking change for users that embed a `wasmcloud-host` in their Rust program. ([PR #114](https://github.com/wasmCloud/wasmCloud/pull/114) and [PR #135](https://github.com/wasmCloud/wasmCloud/pull/135))
+* Changed fields on the `Host` struct to allow it to be sent between threads ([PR #132](https://github.com/wasmCloud/wasmCloud/pull/132))
+{{</ changelog >}}
+
+{{< changelog "Fixed" >}}
+* Fixed a bug where loading a capability provider caused a SIGSEGV on Linux ([PR #99](https://github.com/wasmCloud/wasmCloud/pull/99))
+* Fixed a bug where the live update operation didn't allow for differing OCI references ([PR #128](https://github.com/wasmCloud/wasmCloud/pull/128))
+{{</ changelog >}}
 
 ### Release 0.15.0
 
@@ -28,16 +59,21 @@ The **0.15.0** release is the single biggest release we've had since the project
 
 {{</ changelog >}}
 
-{{< changelog "Removed" >}}
-{{</ changelog >}}
-
-{{< changelog "Fixed" >}}
-{{</ changelog >}}
-
-{{< changelog "Security" >}}
-{{</ changelog >}}
-
-{{< changelog "Unreleased" >}}
-{{</ changelog >}}
-
 <hr/>
+<!-- {{< changelog "added" >}}
+{{</ changelog >}} -->
+
+<!-- {{< changelog "changed" >}}
+{{</ changelog >}} -->
+
+<!-- {{< changelog "Removed" >}}
+{{</ changelog >}} -->
+
+<!-- {{< changelog "Fixed" >}}
+{{</ changelog >}} -->
+
+<!-- {{< changelog "Security" >}}
+{{</ changelog >}} -->
+
+<!-- {{< changelog "Unreleased" >}}
+{{</ changelog >}} -->


### PR DESCRIPTION
Additionally, I included the string "Changelog" in the release notes so you can search for it in the site search bar. I'm happy to move that out of the title if it looks ugly