### PR TITLE
Removed references to NATS in our starting tutorials

### DIFF
--- a/content/app-dev/create-actor/_index.en.md
+++ b/content/app-dev/create-actor/_index.en.md
@@ -11,7 +11,7 @@ Creating an actor with **wasmcloud** involves a few steps. First, you'll need to
 * TinyGo
 * AssemblyScript
 
-Next, you'll need to use the appropriate tooling to create a new actor in your language of choice. The current (`0.2.0`) version of the **wash** CLI does not **yet** support code generation or the production of scaffolding. As such, if you want scaffolding for Rust, you should use `cargo generate`, which is what this guide assumes. Check the [actor interfaces](https://github.com/wasmcloud/actor-interfaces) GitHub repository for information on scaffolding for other languages.
+Next, you'll need to use the appropriate tooling to create a new actor in your language of choice. Currently the **wash** CLI does not **yet** support code generation or the production of scaffolding. As such, if you want scaffolding for Rust, you should use `cargo generate`, which is what this guide assumes. Check the [actor interfaces](https://github.com/wasmcloud/actor-interfaces) GitHub repository for information on scaffolding for other languages.
 
 This guide will walk you through the following steps to creating an actor:
 

--- a/content/app-dev/create-actor/handlers.md
+++ b/content/app-dev/create-actor/handlers.md
@@ -11,7 +11,7 @@ First, we'll need to add a reference to the HTTP server actor interface and JSON
 
 ```toml
 serde_json = "1.0.59"
-wasmcloud-actor-http-server = { version = "0.2.2", branch = "main", features = ["guest"]}
+wasmcloud-actor-http-server = { version = "0.2.2", features = ["guest"]}
 ```
 
 In this case we're using a git reference for the actor interface,

--- a/content/app-dev/create-actor/run.md
+++ b/content/app-dev/create-actor/run.md
@@ -5,24 +5,20 @@ weight: 5
 draft: false
 ---
 
-### Pre-Requisites
-
 In this guide we're going to start the actor "the long way" so that you can get a feel for all of the moving parts of the process. Our tooling documentation should help you get actors started easier once you've been through this guide.
 
-### Start NATS
-Refer to the [Starting NATS](../../../overview/getting-started#starting-nats) section of the getting started guide for instructions on how to start NATS. NATS will be required to start your actor in the following steps.
+### Pre-Requisites
+To run this part of the guide, you'll need a local OCI (Open Container Initiative)-compliant registry. The easiest way to get an OCI registry running locally is with `docker` and it's `registry` image.
 
 ### Deploy a Local Docker Registry
 
-The `wash` tooling and the embedded REPL launch actors and capability providers from OCI (Open Container Initiative)-compliant registries. One such registry is the docker registry. You can run this locally with the following command:
+The `wash` tooling and the embedded REPL launch actors and capability providers from OCI-compliant registries. One such registry is the docker registry. You can run this locally with the following command:
 
 ```
 docker run -d -p 5000:5000 --restart=always --name registry registry:2
 ```
 
 For more information on running the registry, you can read [Docker's documentation](https://docs.docker.com/registry/deploying/).
-
-Note: if you used the `docker-compose` script as described in the [Starting NATS](../../../overview/getting-started#starting-nats) section, you do not need to start the registry manually.
 
 ### Push Your Actor
 

--- a/content/overview/getting-started/_index.en.md
+++ b/content/overview/getting-started/_index.en.md
@@ -8,45 +8,7 @@ draft: false
 We'll be taking a tour through some of the most common activities in the wasmcloud ecosystem, like starting and configuring [actors](../../reference/host-runtime/actors/) and [capability providers](../../reference/host-runtime/capabilities/).
 
 ### Prerequisites
-In order to follow this guide, you'll need a few things:
-- `wash` (installation covered on [the previous page](../installation))
-- [nats-server](https://docs.nats.io/nats-server/installation) **OR** [docker](https://docs.docker.com/engine/install/), recommended with [docker-compose](https://docs.docker.com/compose/install/)
-
-### Starting NATS
-[NATS](https://nats.io/) is a message broker used by wasmcloud's self-managing [lattice](../../reference/lattice/) network.
-
-In a terminal window, use one of the following options to launch `nats-server` locally. We recommend using `docker-compose` as it will also launch services that are used in other places in this documentation.
-
-{{% tabs %}}
-   {{% tab "docker-compose" %}}
-    # This file is located in the wash repository under tools/
-    cat <<EOF > docker-compose.yml
-    version: "3"
-    services:
-      registry:
-        image: registry:2
-        ports:
-        - "5000:5000"
-      nats:
-        image: nats:2.1.9
-        ports:
-        - "6222:6222"
-        - "4222:4222"
-        - "8222:8222"
-      redis:
-        image: redis:6.0.9
-        ports:
-        - "6379:6379"   
-    EOF
-    docker-compose up
-   {{% /tab %}}
-   {{% tab "docker" %}}
-    docker run -p 4222:4222 -ti nats:latest
-   {{% /tab %}}
-   {{% tab "nats-server binary" %}}
-    nats-server -a 0.0.0.0 -p 4222
-   {{% /tab %}}
- {{% /tabs %}}
+In order to follow this guide, you'll need `wash` (installation covered on [the previous page](../installation)).
 
 ### Running your first wasmcloud host
 In a separate terminal window, run the following command to launch an interactive wasmcloud REPL environment, including a preconfigured wasmcloud host:


### PR DESCRIPTION
This PR simply removes the NATS prerequisite from the Run your Actor and getting started tutorials. NATS is still an important part of wasmcloud core and it belongs in the sections on lattice.

Something I considered with this PR is a section on the REPL with standalone mode vs lattice connected mode, but I believe this will be best addressed alongside an example where we show off a lattice-connected demo and add that to our documentation.