### PR TITLE
Removed docker registry prerequisite for run-the-actor

### DIFF
--- a/content/app-dev/create-actor/run.md
+++ b/content/app-dev/create-actor/run.md
@@ -8,27 +8,7 @@ draft: false
 In this guide we're going to start the actor "the long way" so that you can get a feel for all of the moving parts of the process. Our tooling documentation should help you get actors started easier once you've been through this guide.
 
 ### Pre-Requisites
-To run this part of the guide, you'll need a local OCI (Open Container Initiative)-compliant registry. The easiest way to get an OCI registry running locally is with `docker` and it's `registry` image.
-
-### Deploy a Local Docker Registry
-
-The `wash` tooling and the embedded REPL launch actors and capability providers from OCI-compliant registries. One such registry is the docker registry. You can run this locally with the following command:
-
-```
-docker run -d -p 5000:5000 --restart=always --name registry registry:2
-```
-
-For more information on running the registry, you can read [Docker's documentation](https://docs.docker.com/registry/deploying/).
-
-### Push Your Actor
-
-Next you'll want to push your actor to the local registry. If you haven't configured authentication or any other restrictions, you should be able to use the following `wash` command to push it to the registry:
-
-```
-wash reg push --insecure localhost:5000/(image):(tag) ./target/wasm32-unknown-unknown/debug/(actor)_s.wasm
-```
-
-For example, you might use `newactor` and `v1` as the image and tag respectively, giving you a local registry URL (you'll need to remember this) of `http://localhost:5000/newactor:v1`. Make sure the path you supply here is to the _signed_ version of your actor's WebAssembly module.
+To run this part of the guide, you'll need `wash`. If you don't have `wash`, installation steps are covered on [the installation page](../../../overview/installation)).
 
 ### Launch the Actor
 
@@ -36,10 +16,10 @@ There are countless ways to run the actor we just created, but the easiest is pr
 
 ![Wash Up](../wash_up.png)
 
-Once inside the wash REPL, you can issue this command to start the actor (make sure you change the OCI URL to the one you used in the previous step):
+Once inside the wash REPL, you can issue this command to start the actor. Make sure the path you supply here is to the _signed_ version of your actor's WebAssembly module.
 
 ```
-ctl start actor localhost:5000/newactor:v1
+ctl start actor myactor_s.wasm
 ```
 
 Next, we'll need to start the HTTP Server. Fortunately, the wasmcloud official HTTP server capability provider is published in Azure Container Registry, so you can start it with the following REPL command:
@@ -54,10 +34,10 @@ With both the provider and the actor running, the only thing left to do is _link
 ctl link (ACTOR_MODULE_KEY) VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver PORT=8080
 ```
 
-To get your `(ACTOR_MODULE_KEY)`, a 56-character string beginning with the letter **M**, you can check them from inside the REPL by inspecting the local registry:
+To get your `(ACTOR_MODULE_KEY)`, a 56-character string beginning with the letter **M**, you can check them from inside the REPL by inspecting the local signed wasm:
 
 ```
-claims inspect --insecure localhost:5000/newactor:v1
+claims inspect --insecure myactor_s.wasm
 ```
 
 You should see in the log output that the actor configuration was passed and you should see an HTTP server starting on port 8080. Now you can type the following in a separate terminal prompt to curl your newly started endpoint:

--- a/content/app-dev/create-provider/testing.md
+++ b/content/app-dev/create-provider/testing.md
@@ -11,7 +11,7 @@ The easiest way to test your new capability provider is as follows:
 
 1. Upload the newly-created _provider archive_ to the local OCI registry (You can use `wash reg push`)
 
-1. Upload an actor that utilizes this provider to the local OCI registry (`wash reg push`)
+1. Upload an actor that utilizes this provider to the local OCI registry (`wash reg push`), or simply load a signed actor file. An example of doing this can be found in the [run the actor](../../create-actor/run/#launch-the-actor) section.
 
 1. Use `ctl link` inside the `wash up` REPL to establish a link (no values necessary) between the actor and the provider. Note that even if you don't supply configuration values, an actor must be linked to a provider (and have sufficient claims) before it can communicate with it.
 

--- a/content/overview/getting-started/_index.en.md
+++ b/content/overview/getting-started/_index.en.md
@@ -79,7 +79,8 @@ You can use the following command to `link` your actor and provider.
 ```shell
 ctl link MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver PORT=8080
 ```
-**Note:** If you're running MacOS you might receive a message asking if you want `wash` to receive incoming network connections. You should click "Allow", this is just setting up the provider's local HTTP server to listen on port 8080. This creates a temporary firewall rule to allow us to locally make HTTP requests to this HTTP server.
+**Note:** If you're running MacOS you might receive a message asking if you want `wash` to receive incoming network connections. Selecting either `Deny` or `Allow` will work for this tutorial where you are making a request to your own local machine. If you want to make this request from an environment that's not on your local machine, you may need to click `Allow` which will create a temporary firewall rule for that port.
+
 Once you see that the link has been advertised, you are ready to send a request to your actor.
 
 #### Interacting with your actor


### PR DESCRIPTION
Continuing our quest to make the onboarding experience smooth as 🧈 , with `wash` 0.4.2 (https://github.com/wasmCloud/wash/pull/122) users can now load actors from disk, so they do not need to launch a local docker registry.