### PR TITLE
Add wapc installation script

### DIFF
--- a/content/app-dev/create-provider/cdd.md
+++ b/content/app-dev/create-provider/cdd.md
@@ -118,7 +118,7 @@ type PaymentMethodList {
 
 At the moment, the code generation for **waPC** doesn't isolate the guest and host portions of the shared code the way we would like. Therefore, until the automated generation requires no hand-manipulation of the files, you can use existing actor interfaces as an example for how to apply minor tweaks. You can see the entire [payments-interface](https://github.com/wasmcloud/examples/tree/main/payments/payments-interface) Rust project to see what the code should look like.
 
-Before proceeding to the next step, you should create your own `payments-interface` project by copying the one from the github repository. This project contains the schema that we've just created, a `Makefile` that generates code into a `src/generated.rs` file, and the appropriate dependencies in `Cargo.toml`.
+Before proceeding to the next step, you should create your own `payments-interface` project by copying the one from the github repository. This project contains the schema that we've just created, a `Makefile` that generates code into a `src/generated.rs` file, and the appropriate dependencies in `Cargo.toml`. If you haven't already, make sure to install the `wapc` command line tool as described [here](https://github.com/wapc/cli).
 
 If you want to learn more about using [waPC](/reference/wapc) to generate code from widl schemas, you can consult the reference guide.
 

--- a/content/app-dev/std-caps/_index.en.md
+++ b/content/app-dev/std-caps/_index.en.md
@@ -28,6 +28,22 @@ use wasmcloud_actor_graphdb as graph;
 use graph::*;
 ```
 
+### Sign actor with the capabilities you use
+
+Once you have the wasm module that depends on any capability provider, it needs to be signed to be allowed to use that provider. This is done by adding the appropriate flag to the `wash claims sign` command. The command `wash claims sign --help` will list the standard options and the flags needed for the standard capabilities. Change the corresponding lines in the `Makefile` to reflect the providers you are using (note: there are two places to change). Here is an excerpt where we added the httpserver (`-q`) and keyvalue (`-k`) providers:
+
+```
+build:
+        @$(CARGO) build
+        wash claims sign -q -k $(DEBUG)/<actor>.wasm --name "<actor>" --ver $(VERSION) --rev $$(( $(REVISION) + 1 ))
+        wash claims inspect $(DEBUG)/<actor>_s.wasm
+...
+release:
+        @$(CARGO) build --release
+        wash claims sign -q -k $(RELEASE)/<actor>.wasm --name "<actor>" --ver $(VERSION) --rev 0
+        wash claims inspect $(RELEASE)/<actor>_s.wasm
+```
+
 ### Start and Link your Actors
 
 We've covered starting and linking actors in a few places throughout the documentation. Refer to the [Run the Actor](/app-dev/create-actor/run) section of the application development guide for more information.


### PR DESCRIPTION
When following the tutorial and you come to contract driven design, you have not been required to install `wapc` so when you are asked to generate the code from widl, you first need to install wapc. I just added a sentence about this and the link to wapc repo with installation instructions. 