### PR TITLE
Update docker run

### DIFF
--- a/content/overview/getting-started/_index.en.md
+++ b/content/overview/getting-started/_index.en.md
@@ -146,7 +146,7 @@ Look for something like:
 Once you locate the value, go ahead and export it as an environment variable:
 
 
-{{% /tab %}}
+{{% tabs %}}
 {{% tab "Unix" %}}
 
 ```

--- a/content/overview/getting-started/_index.en.md
+++ b/content/overview/getting-started/_index.en.md
@@ -128,12 +128,45 @@ In response, you should receive your request object (notice the path argument):
 
 Feel free to try out different methods of making a request to your actor, including adding headers or using a different HTTP method to see different outputs.
 
-Instead of using `curl`, you can also _directly invoke_ actors' registered functions using `wash call`. The function that "echoes" this HTTP request is a part of the interface `wasmcloud:httpserver` and has the operation name `HandleRequest`. We can make this request directly to the actor if we supply the correct parameters.
+Instead of using `curl`, you can also _directly invoke_ actors' registered functions using `wash call`. The function that "echoes" this HTTP request is a part of the interface `wasmcloud:httpserver` and has the operation name `HandleRequest`. We can make this request directly to the actor if we supply the correct parameters. Because this is mimicking the invocation made by a real host, you'll also need to use a cluster seed that's a valid issuer of invocations. For our purposes, we can use the one used to launch the host, but keep in mind this is a secret key and should not be shared.
 
-Here's an example of using `wash call` to mimic the previous `curl` command. Note that this is not interacting with the `HTTP Server` provider, and we don't need it to be running or linked for this operation to succeed:
+To find your cluster seed, take a look at the logs and look for a 56 character ID that starts with **SC**. You can find the logs either in your terminal where you ran the wasmCloud host, or relative to where you unpacked the application tarball in the file `var/log/erlang.log.1`
+
+Look for something like:
 
 ```shell
-wash call MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 HandleRequest '{"method": "GET", "path": "/echo", "body": "", "queryString":"","header":{}}'
+08:36:10.814 [info] Host NBIF7UHMVSLGXHVCD7KL6NS4RC5PH7CERDL4MF7UR3D4QNJ524UUWN4F started.
+08:36:10.814 [info] Valid cluster signers CDLND22ZY7ZID5XEIXMLRWLUXL5NOI6DGECSAXAHT4GONMXWRARTR6M7
+08:36:10.814 [warn] ** WARNING. You are using an ad hoc generated cluster seed.
+08:36:10.814 [warn]    For any other host or CLI tool to communicate with this host, you MUST copy the following seed key and
+08:36:10.814 [warn]    use it as the value of the WASMCLOUD_CLUSTER_SEED environment variable:
+08:36:10.814 [warn]    SCAJIRZPJGI2ODWHALXJ5U7ZRC7MR27JMJOPLIKMDJ3QNQGA3TCPDFENDI
+```
+
+Once you locate the value, go ahead and export it as an environment variable:
+
+
+{{% /tab %}}
+{{% tab "Unix" %}}
+
+```
+export WASMCLOUD_CLUSTER_SEED=SCAJIRZPJGI2ODWHALXJ5U7ZRC7MR27JMJOPLIKMDJ3QNQGA3TCPDFENDI
+```
+
+{{% /tab %}}
+{{% tab "Windows Powershell" %}}
+
+```
+$env:WASMCLOUD_CLUSTER_SEED = SCAJIRZPJGI2ODWHALXJ5U7ZRC7MR27JMJOPLIKMDJ3QNQGA3TCPDFENDI
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+`wash` will automatically use this cluster seed. Alternatively, you can always supply it as a command line flag `--cluster-seed` to the `call` operation. Here's an example of using `wash call` to mimic the previous `curl` command. Note that this is not interacting with the `HTTP Server` provider, and we don't need it to be running or linked for this operation to succeed:
+
+```shell
+wash call MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 HttpServer.HandleRequest '{"method": "GET", "path": "/echo", "body": "", "queryString":"","header":{}}'
 ```
 
 ⚠️ `call` only works here because the parameters in the JSON payload are _exactly_ the same in terms of fields, shape, and data types as the payload that the actor is expecting. If a field is missing, or a data type is incorrect, the actor will reject the call.

--- a/content/overview/installation/install-with-docker.md
+++ b/content/overview/installation/install-with-docker.md
@@ -19,6 +19,9 @@ docker-compose up -d
 
 To download the wasmCloud host and run it in the current terminal:
 
+{{% tabs %}}
+{{% tab "Linux" %}}
+
 ```
 docker run --network host \
   --env WASMCLOUD_RPC_HOST=0.0.0.0 \
@@ -27,7 +30,27 @@ docker run --network host \
   wasmcloud/wasmcloud_host:latest
 ```
 
+{{% /tab %}}
+{{% tab "Mac" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
 The host will run until you type ctrl-c or close the terminal window. To start the host in the background, add a `-d` flag:
+
+{{% tabs %}}
+{{% tab "Linux" %}}
 
 ```
 docker run --network host -d \
@@ -36,6 +59,25 @@ docker run --network host -d \
   --name wasmcloud \
   wasmcloud/wasmcloud_host:latest
 ```
+
+{{% /tab %}}
+{{% tab "Mac" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+
 
 If the wasmCloud host is running in docker in the background, you can view its logs (live) with 
 

--- a/content/overview/installation/install-with-docker.md
+++ b/content/overview/installation/install-with-docker.md
@@ -20,13 +20,21 @@ docker-compose up -d
 To download the wasmCloud host and run it in the current terminal:
 
 ```
-docker run --name wasmcloud wasmcloud/wasmcloud_host:latest
+docker run --network host \
+  --env WASMCLOUD_RPC_HOST=0.0.0.0 \
+  --env WASMCLOUD_CTL_HOST=0.0.0.0 \
+  --name wasmcloud \
+  wasmcloud/wasmcloud_host:latest
 ```
 
 The host will run until you type ctrl-c or close the terminal window. To start the host in the background, add a `-d` flag:
 
 ```
-docker run -d --name wasmcloud wasmcloud/wasmcloud_host:latest
+docker run --network host -d \
+  --env WASMCLOUD_RPC_HOST=0.0.0.0 \
+  --env WASMCLOUD_CTL_HOST=0.0.0.0 \
+  --name wasmcloud \
+  wasmcloud/wasmcloud_host:latest
 ```
 
 If the wasmCloud host is running in docker in the background, you can view its logs (live) with 


### PR DESCRIPTION
The previous `docker run` command in the getting started section would not allow the container to connect to NATS properly. This PR adds a method to do it for Linux, but the `--network host` option is not available on Mac and Windows. We may want to consider the steps to create a docker network to keep it a little more cross-platform neutral.

@thomastaylor312 @stevelr @autodidaddict looking for a little bit of docker help here as I'm not sure the best practice or how we practically do this on Windows. For mac, we can do the following:
```
docker run --env WASMCLOUD_RPC_HOST=host.docker.internal --env WASMCLOUD_CTL_HOST=host.docker.internal -p 4000:4000 -it --rm wasmcloud/wasmcloud_host:latest
```

however, as you can see we'd have to forward every port that we use in the tutorials. I'm not sure if this works on Windows