### PR TITLE
update docker run commands

### DIFF
--- a/content/overview/installation/install-with-docker.md
+++ b/content/overview/installation/install-with-docker.md
@@ -19,15 +19,65 @@ docker-compose up -d
 
 To download the wasmCloud host and run it in the current terminal:
 
+{{% tabs %}}
+{{% tab "Linux" %}}
+
 ```
-docker run --name wasmcloud wasmcloud/wasmcloud_host:latest
+docker run --network host \
+  --env WASMCLOUD_RPC_HOST=0.0.0.0 \
+  --env WASMCLOUD_CTL_HOST=0.0.0.0 \
+  --name wasmcloud \
+  wasmcloud/wasmcloud_host:latest
 ```
+
+{{% /tab %}}
+{{% tab "Mac" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% /tabs %}}
 
 The host will run until you type ctrl-c or close the terminal window. To start the host in the background, add a `-d` flag:
 
+{{% tabs %}}
+{{% tab "Linux" %}}
+
 ```
-docker run -d --name wasmcloud wasmcloud/wasmcloud_host:latest
+docker run --network host -d \
+  --env WASMCLOUD_RPC_HOST=0.0.0.0 \
+  --env WASMCLOUD_CTL_HOST=0.0.0.0 \
+  --name wasmcloud \
+  wasmcloud/wasmcloud_host:latest
 ```
+
+{{% /tab %}}
+{{% tab "Mac" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+```
+???
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+
 
 If the wasmCloud host is running in docker in the background, you can view its logs (live) with 
 
@@ -37,3 +87,4 @@ docker logs -f wasmcloud
 
 
 That's it! Let's move on to [Getting started](/overview/getting-started/)
+


### PR DESCRIPTION
The previous `docker run` command in the getting started section would not allow the container to connect to NATS properly. This PR adds a method to do it for Linux, but the `--network host` option is not available on Mac and Windows. We may want to consider the steps to create a docker network to keep it a little more cross-platform neutral.

@thomastaylor312 @stevelr @autodidaddict looking for a little bit of docker help here as I'm not sure the best practice or how we practically do this on Windows. For mac, we can do the following:
```
docker run --env WASMCLOUD_RPC_HOST=host.docker.internal --env WASMCLOUD_CTL_HOST=host.docker.internal -p 4000:4000 -it --rm wasmcloud/wasmcloud_host:latest
```

however, as you can see we'd have to forward every port that we use in the tutorials. I'm not sure if this works on Windows