### PR TITLE
Use Docker Compose v2 in setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/
 .DS_Store
 
 .hugo_build.lock
+.vscode

--- a/content/overview/installation/_index.en.md
+++ b/content/overview/installation/_index.en.md
@@ -20,11 +20,11 @@ First, let's make sure we have the necessary prerequisites for developing with w
 
 - **Rust SDK**. While other languages will be supported in the future, actor and capability development are supported _Rust-first_, so you will also want to [install Rust](https://www.rust-lang.org/tools/install) if you haven't already.
 
-- **unix utilities** if you are on a non-linux platform, you will want a package manager such as homebrew (mac) or chocolatey (windows) that can install common utilities. Using your favorite package manager, make sure that you have these installed: **bash**, **git**, **jq**, and **make**
+- **Unix utilities** if you are on a non-linux platform, you will want a package manager such as homebrew (mac) or chocolatey (windows) that can install common utilities. Using your favorite package manager, make sure that you have these installed: **bash**, **git**, **jq**, and **make**
 
   - We recommend gnu make version 4.3 or later. (for Mac users: you'll need to add the homebrew-installed make to your path _before_ the one in `/usr/bin`).
 
-- [**docker**](https://docs.docker.com/get-docker/) Docker provides an easy way to start all the services you need for a development environment: nats, a local oci registry. We recommend using the newest version of Docker available on your machine, or at least a version that supports [Docker Compose v2](https://docs.docker.com/compose/cli-command/).
+- [**Docker**](https://docs.docker.com/get-docker/) provides an easy way to start all the services you need for a development environment: NATS, a local OCI registry. We recommend using the newest version of Docker available on your machine, or at least a version that supports [Docker Compose v2](https://docs.docker.com/compose/cli-command/).
 
 ### Install wash
 
@@ -33,7 +33,7 @@ The wash CLI is the main tool you'll be using for wasmcloud development. Select 
 {{% tabs %}}
 {{% tab "Ubuntu/Debian" %}}
 
-```
+```bash
 curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.deb.sh | sudo bash
 sudo apt install wash
 ```
@@ -41,7 +41,7 @@ sudo apt install wash
 {{% /tab %}}
 {{% tab "Fedora" %}}
 
-```
+```bash
 curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.rpm.sh | sudo bash
 sudo dnf install wash
 ```
@@ -49,14 +49,14 @@ sudo dnf install wash
 {{% /tab %}}
 {{% tab "snap" %}}
 
-```
+```bash
  snap install wash --devmode --edge
 ```
 
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
-```
+```bash
 brew tap wasmcloud/wasmcloud
 brew install wash
 ```
@@ -64,14 +64,14 @@ brew install wash
 {{% /tab %}}
 {{% tab "Rust" %}}
 
-```
+```bash
 cargo install wash-cli
 ```
 
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-```
+```bash
 cargo install wash-cli
 ```
 
@@ -88,25 +88,25 @@ NATS is a powerful, cloud native message broker that aims to provide a universal
 
 Installing NATS is quick and easy. Once it's installed, run it with JetStream enabled:
 
-```
+```bash
 nats-server --jetstream
 ```
 
 #### Install and start the wasmCloud host runtime
 
-Before you start the wasmCloud host runtime, nats should already be running.
+Before you start the wasmCloud host runtime, NATS should already be running.
 
 The preferred way to install the wasmCloud host runtime is to download the latest [release](https://github.com/wasmCloud/wasmcloud-otp/releases). Download the `.tar.gz` file into a directory where you want to install the server.
 
 If you are on a Mac, you'll need to run one more command before extracting the release. This command makes it so Gatekeeper will not quarantine parts of the host when you run it:
 
-```
+```bash
 sudo xattr -d com.apple.quarantine x86_64-macos.tar.gz
 ```
 
 Once you have downloaded the release (and run the above command if on a Mac), extract the release using the following command: (replace _ARCH_ with your architecture, and _OS_ with your operating system)
 
-```
+```bash
 tar xzf ARCH-OS.tar.gz
 ```
 
@@ -116,25 +116,25 @@ There are a variety of ways to run the host. To view the command-line options, t
 
 - To start the host running in the current terminal (The host continues running until you ctrl-c or close the terminal window)
 
-  ```
+  ```bash
   bin/wasmcloud_host foreground
   ```
 
 - Alternately, you can start it in the background with
 
-  ```
+  ```bash
   bin/wasmcloud_host start
   ```
 
   and stop it with `bin/wasmcloud_host stop`. You can view the logs with
 
-  ```
+  ```bash
   tail var/log/erlang.log.1
   ```
 
 - If you're already familiar with Elixir and **iex**, Elixir's interactive shell, and want to dive into the host's internals, execute Elixir statements, and set breakpoints, start the host with
 
-  ```
+  ```bash
   bin/wasmcloud_host console
   ```
 
@@ -145,4 +145,5 @@ Once the wasmCloud host has started, go ahead to [Getting started](/overview/get
 The [wasmCloud OTP host runtime](https://github.com/wasmCloud/wasmcloud-otp) and [wash](https://github.com/wasmcloud/wash) repositories are open source on GitHub. Both of these repositories can be cloned and built locally directly. Consult the README file in the respective repository for prerequisites and instructions for compiling and running.
 
 ### Stopping the wasmCloud Host Runtime
+
 There are a number of ways you can stop the runtime, and the recommendation varies with how you started the host. For details, see the [safe shutdown](/reference/host-runtime/safeshutdown) section of the reference guide.

--- a/content/overview/installation/_index.en.md
+++ b/content/overview/installation/_index.en.md
@@ -24,7 +24,7 @@ First, let's make sure we have the necessary prerequisites for developing with w
 
   - We recommend gnu make version 4.3 or later. (for Mac users: you'll need to add the homebrew-installed make to your path _before_ the one in `/usr/bin`).
 
-- [**docker**](https://docs.docker.com/get-docker/) and [**docker-compose**](https://docs.docker.com/compose/install/) Docker provides an easy way to start all the services you need for a development environment: nats, a local oci registry.
+- [**docker**](https://docs.docker.com/get-docker/) Docker provides an easy way to start all the services you need for a development environment: nats, a local oci registry. We recommend using the newest version of Docker available on your machine, or at least a version that supports [Docker Compose v2](https://docs.docker.com/compose/cli-command/).
 
 ### Install wash
 

--- a/content/overview/installation/install-with-docker.md
+++ b/content/overview/installation/install-with-docker.md
@@ -14,13 +14,13 @@ Download the [sample docker-compose file](https://raw.githubusercontent.com/wasm
 
 With the `docker-compose.yml` file in the current directory, start the processes with
 ```
-docker-compose up
+docker compose up
 ```
 
 The host will run until you type ctrl-c or close the terminal window. To start the docker-compose process in the background, add a `-d` flag:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 If the wasmCloud host is running in docker in the background, you can view its logs (live) with 

--- a/content/overview/installation/install-with-docker.md
+++ b/content/overview/installation/install-with-docker.md
@@ -5,30 +5,28 @@ weight: 1
 draft: false
 ---
 
-Let's install NATS and the wasmCloud host runtime with docker. You should have already installed [prerequisites and wash](/overview/installation/).
+Let's install NATS and the wasmCloud host runtime with Docker. You should have already installed [prerequisites and wash](/overview/installation/). Additionally, make sure your Docker install has [Compose v2](https://docs.docker.com/compose/cli-command/#installing-compose-v2).
 
-
-Download the [sample docker-compose file](https://raw.githubusercontent.com/wasmCloud/examples/main/docker/docker-compose.yml) and put it into your work directory. This compose file will run nats, a local OCI registry, a redis container, and the `wasmcloud_host` container. In this format it's easy to run all the necessary services for a wasmCloud host with only a docker installation.
+Download the [sample docker-compose file](https://raw.githubusercontent.com/wasmCloud/examples/main/docker/docker-compose.yml) and put it into your work directory. This compose file will run NATS, a local OCI registry, a Redis container, and the `wasmcloud_host` container. In this format it's easy to run all the necessary services for a wasmCloud host with only a docker installation.
 
 #### Starting the wasmCloud host with docker
 
 With the `docker-compose.yml` file in the current directory, start the processes with
-```
+
+```bash
 docker compose up
 ```
 
 The host will run until you type ctrl-c or close the terminal window. To start the docker-compose process in the background, add a `-d` flag:
 
-```
+```bash
 docker compose up -d
 ```
 
-If the wasmCloud host is running in docker in the background, you can view its logs (live) with 
+If the wasmCloud host is running in docker in the background, you can view its logs (live) with
 
-```
+```bash
 docker logs -f wasmcloud
 ```
 
-
 That's it! Let's move on to [Getting started](/overview/getting-started/)
-


### PR DESCRIPTION
Docker Compose v2 (`docker compose`) is available now, and is recommended for use over v1 (`docker-compose`).

I've updated the install-with-docker commands to reflect this.