### PR TITLE
Auto-generate issues for tracking Meeting updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-meeting-update.md
+++ b/.github/ISSUE_TEMPLATE/community-meeting-update.md
@@ -1,0 +1,31 @@
+---
+name: Community Meeting Update
+about: Track the update of all the things pertaining to a Community Meeting
+title: Community Meeting - {{ date | date('dddd, MMMM Do') }}
+labels: community, meeting, update
+assignees: jordan-rash, LiamRandall
+---
+
+> This issue should only be closed by a commit to the site with the minutes and
+> artifacts for easy referencing
+
+### Attendance
+
+### ToDo Items
+
+- [ ] YouTube Video
+- [ ] Twitter Post
+- [ ] Reddit Post
+- [ ] LinkedIn Post
+- [ ] Update site with minutes
+
+### Artifacts
+
+YouTube Video:
+Tweet:
+
+### Demos:
+
+### Minutes:
+
+### Link references:

--- a/.github/workflows/cron-community-issue.yml
+++ b/.github/workflows/cron-community-issue.yml
@@ -1,0 +1,23 @@
+name: Create an issue for tracking meeting
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * WED'
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Meeting Issue
+        id: create-issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/community-meeting-update.md
+      - run: 'echo Created ${{ steps.create-issue.outputs.url }}'
+        


### PR DESCRIPTION
This PR contains an issue template and a GHA that will create a new
issue at the start of the weekly meeting.  Will be used as a checklist
to ensure all the things needed are getting done :-)

Signed-off-by: Jordan Rash <15827604+jordan-rash@users.noreply.github.com>