### PR TITLE
Added getting started info for tinygo

### DIFF
--- a/content/app-dev/create-actor/_index.en.md
+++ b/content/app-dev/create-actor/_index.en.md
@@ -5,9 +5,9 @@ weight: 2
 draft: false
 ---
 
-Creating an actor with wasmCloud is simple and easy. Today, we support actors created in **Rust** but we will soon have support for other languages as those languages develop better tooling and support for WebAssembly.
+Creating an actor with wasmCloud is simple and easy. Today, we support actors created in **Rust** and **TinyGo** but we will soon have support for other languages as those languages develop better tooling and support for WebAssembly.
 
-To perform the steps in this guide, you'll need to have completed [installation](/overview/installation/) of the wasmCloud host and prerequisites, and the Rust [wasm32 target](../getting-started/).
+To perform the steps in this guide, you'll need to have completed [installation](/overview/installation/) of the wasmCloud host and prerequisites, and if you're using Rust, the [wasm32 target](../getting-started/) installed.
 
 This guide will walk you through the following steps to create an actor:
 

--- a/content/app-dev/create-actor/generate.md
+++ b/content/app-dev/create-actor/generate.md
@@ -5,47 +5,15 @@ weight: 3
 draft: false
 ---
 
+{{% tabs %}}
+{{% tab "Rust" %}}
 Creating the scaffold for a new actor in Rust is easy. We will create an actor that accepts an HTTP request and responds with "Hello World". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The last term on the command `hello` is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
 ```shell
-wash new actor hello
+wash new actor hello --template-name hello
 ```
 
-Let's change into the newly-created folder `hello` and take a look at the generated project. The file `src/lib.rs` should look something like this:
-
-```rust
-use wasmbus_rpc::actor::prelude::*;
-use wasmcloud_interface_httpserver::{HttpRequest, HttpResponse, HttpServer, HttpServerReceiver};
-
-#[derive(Debug, Default, Actor, HealthResponder)]
-#[services(Actor, HttpServer)]
-struct HelloActor {}
-
-/// Implementation of HttpServer trait methods
-#[async_trait]
-impl HttpServer for HelloActor {
-
-    /// Returns a greeting, "Hello World", in the response body.
-    /// If the request contains a query parameter 'name=NAME', the
-    /// response is changed to "Hello NAME"
-    async fn handle_request(
-        &self,
-        _ctx: &Context,
-        req: &HttpRequest,
-    ) -> std::result::Result<HttpResponse, RpcError> {
-        let text = form_urlencoded::parse(req.query_string.as_bytes())
-            .find(|(n, _)| n == "name")
-            .map(|(_, v)| v.to_string())
-            .unwrap_or_else(|| "World".to_string());
-
-        Ok(HttpResponse {
-            body: format!("Hello {}", text).as_bytes().to_vec(),
-            ..Default::default()
-        })
-    }
-}
-
-```
+Let's change into the newly-created folder `hello` and take a look at the generated project. The file `src/lib.rs` includes an imports section, a struct `HelloActor`, and an `impl` block that implements the `HttpServer` trait for the actor struct. Let's walk through these sections in detail.
 
 Note the two lines near the top of the source code file:
 
@@ -66,9 +34,78 @@ struct HelloActor {}
 `HelloActor` is the name of your actor - if you chose a different project name, the actor name will include your project name.
 
 The two lines above the actor name invoke Rust macros that generate - at compile time - nearly all of the scaffolding needed to build an actor. The `HealthResponder` term generates a function that automatically responds to health check queries from the wasmCloud host. The `#[services(...)]` line declares the services ('traits', in Rust) that your actor implements, and generates message handling code for those interfaces. All actors implement the `Actor` interface. The `HttpServer` entry declares that the actor will also implement that interface, and requires an implementation of that trait's method: `handle_request`.
+```rust
+#[async_trait]
+impl HttpServer for HelloActor {
+    /// Returns a greeting, "Hello World", in the response body.
+    /// If the request contains a query parameter 'name=NAME', the
+    /// response is changed to "Hello NAME"
+    async fn handle_request(
+        &self,
+        _ctx: &Context,
+        req: &HttpRequest,
+    ) -> std::result::Result<HttpResponse, RpcError> {
+        let text=form_urlencoded::parse(req.query_string.as_bytes())
+            .find(|(n, _)| n == "name")
+            .map(|(_, v)| v.to_string())
+            .unwrap_or_else(|| "World".to_string());
+        Ok(HttpResponse {
+            body: format!("Hello {}", text).as_bytes().to_vec(),
+            ..Default::default()
+        })
+    }
+}
+```
 
 Within the `handle_request` method, the actor receives the HTTP request, and returns an HttpResponse, which is sent back to the http client (such as a `curl` command or a web browser). We'll look into the details of that method, and customize it, shortly.
+{{% /tab %}}
 
+{{% tab "TinyGo" %}}
+wasmCloud introduced support for generating a TinyGo project in wash `v0.11.0`. We will create an actor that accepts an HTTP request and responds with "Hello World". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The last term on the command `hello` is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
+
+```shell
+wash new actor hello --template-name echo-tinygo
+```
+
+Let's change into the newly-created folder `hello` and take a look at the generated project. The file `hello.go` will include imports, a `main` function, a `Hello` struct, and an HTTP handler. Let's walk through these pieces in depth.
+
+```go
+import (
+	"github.com/wasmcloud/actor-tinygo"
+	"github.com/wasmcloud/interfaces/httpserver/tinygo"
+)
+```
+This shows us that we're using a core wasmCloud package called `actor-tinygo` and we've also declared a dependency on the `interfaces/httpserver/tinygo` package. All first-party wasmCloud interface packages have this naming convention.
+
+Just below that, you'll see:
+
+```go
+func main() {
+	me := Hello{}
+	actor.RegisterHandlers(httpserver.HttpServerHandler(&me), actor.ActorHandler(&me))
+}
+type Hello struct{}
+```
+
+`Hello` is the name of your actor - if you chose a different project name, the actor name will include your project name.
+
+The purpose of the `main` function in your TinyGo module is to use the wasmCloud actor library to register function handlers. In this case, our actor is making use of the `wasmcloud:httpserver` capability to receive and handle HTTP requests and is registering the `HandleRequest` function to do so.
+
+```go
+func (e *Hello) HandleRequest(ctx *actor.Context, req httpserver.HttpRequest) (*httpserver.HttpResponse, error) {
+	r := httpserver.HttpResponse{
+		StatusCode: 200,
+		Header:     make(httpserver.HeaderMap, 0),
+		Body:       []byte("hello"),
+	}
+	return &r, nil
+}
+```
+
+Within the `HandleRequest` method, the actor receives the HTTP request, and returns an HttpResponse with a body of `hello`, which is sent back to the http client (such as a `curl` command or a web browser). We'll look into the details of that method, and customize it, shortly.
+
+{{% /tab %}}
+{{% /tabs %}}
 If you use an IDE that comes with code completion and hover-tooltips, you'll be able to see documentation and get strongly-typed guidance as you develop code to interact with the wasmCloud interfaces.
 
 ### Something's missing

--- a/content/app-dev/create-actor/test.md
+++ b/content/app-dev/create-actor/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Testing the actor"
+title: "Testing the actor (Rust)"
 date: 2018-12-29T10:00:00+00:00
-weight: 4
+weight: 8
 draft: false
 ---
 

--- a/content/app-dev/create-actor/update.md
+++ b/content/app-dev/create-actor/update.md
@@ -70,7 +70,7 @@ You should now see your actor with a `hot reloading` status badge, and you're re
 
 ![hotreloading](../hotreloading.png)
 
-### Making modifications
+### Making modifications (Rust)
 
 Our new actor has come pre-equipped with a message handler that generates a text string in the body of the response. By default, the text is "Hello World", and the greeting changes if the URL contains a name parameter. We will modify the business logic of the actor to select the greeting, using a second URL paramter. In this exercise, you will go through the process of editing code, recompiling, and updating the actor in a live running system.
 

--- a/content/app-dev/getting-started/_index.en.md
+++ b/content/app-dev/getting-started/_index.en.md
@@ -7,7 +7,7 @@ draft: false
 
 Getting started with application development on wasmCloud is pretty simple. The first thing you'll need to do is follow the [installation](/overview/installation) steps outlined in this guide.
 
-Next, make sure you have the language of your choice installed and ready to go. Today, we support **Rust** but support for other languages will be coming soon. 
+Next, make sure you have the language of your choice installed and ready to go. Today, we support **Rust** and **TinyGo** for actors and **Rust** for capability providers, but support for other languages will be coming soon. 
 
 Before you can build [actors](/reference/host-runtime/actors) with Rust, you'll need to have the `wasm32-unknown-unknown` target added to your environment. You can set this up by executing the following command:
 

--- a/content/overview/installation/_index.en.md
+++ b/content/overview/installation/_index.en.md
@@ -8,23 +8,22 @@ draft: false
 
 There are three primary components of a wasmCloud installation:
 
-- The wasmCloud Shell (`wash`)
-- The host runtime
+- The wasmCloud shell, `wash`
+- The wasmCloud host runtime
 - [NATS](https://nats.io) server (v2.7.2 or later)
 
 We will guide you through installation of these components and the other prerequisites.
 
 ### Prerequisites
 
-First, let's make sure we have the necessary prerequisites for developing with wasmCloud:
+First, let's make sure we have the necessary prerequisites for developing with wasmCloud..
 
-- **Rust SDK**. While other languages will be supported in the future, actor and capability development are supported _Rust-first_, so you will also want to [install Rust](https://www.rust-lang.org/tools/install) if you haven't already.
+- **Language SDKs**: wasmCloud supports [TinyGo](https://tinygo.org/getting-started/install/) and [Rust](https://www.rust-lang.org/tools/install) for actor development and [Rust](https://www.rust-lang.org/tools/install) for capability provider development. Ensure you have a toolchain installed for your preference of language, for now we recommend installing Rust regardless and 
 
-- **Unix utilities** if you are on a non-linux platform, you will want a package manager such as homebrew (mac) or chocolatey (windows) that can install common utilities. Using your favorite package manager, make sure that you have these installed: **bash**, **git**, **jq**, and **make**
-
+- **Unix utilities**: We include Makefiles with our project templates to simplify development that assume some common command line utilities. Using your favorite package manager, make sure that you have these installed: **bash**, **git**, **jq**, and **make**
   - We recommend gnu make version 4.3 or later. (for Mac users: you'll need to add the homebrew-installed make to your path _before_ the one in `/usr/bin`).
 
-- [**Docker**](https://docs.docker.com/get-docker/) provides an easy way to start all the services you need for a development environment: NATS, a local OCI registry. We recommend using the newest version of Docker available on your machine, or at least a version that supports [Docker Compose v2](https://docs.docker.com/compose/cli-command/).
+> If you prefer to use Docker and not install anything locally, you can follow our [install with Docker](./install-with-docker]) instructions instead of the ones below. You'll still want to have `wash` as mentioned above for the guides in the documentation.
 
 ### Install wash
 
@@ -50,7 +49,7 @@ sudo dnf install wash
 {{% tab "snap" %}}
 
 ```bash
- snap install wash --devmode --edge
+snap install wash --devmode --edge
 ```
 
 {{% /tab %}}
@@ -62,86 +61,106 @@ brew install wash
 ```
 
 {{% /tab %}}
-{{% tab "Rust" %}}
+{{% tab "Windows" %}}
 
 ```bash
 cargo install wash-cli
 ```
 
 {{% /tab %}}
-{{% tab "Windows" %}}
+{{% tab "Rust" %}}
 
+`wash` can be installed with `cargo` in the case that your platform isn't listed
 ```bash
-choco install wash
+cargo install wash-cli
 ```
 
 {{% /tab %}}
 {{% /tabs %}}
 
-### Installing NATS and the wasmCloud host runtime
-
-You can install NATS and the wasmCloud host runtime with or without docker. If you have docker installed, the procedure for [installing with docker](./install-with-docker/) is slightly shorter than the procedure below.
-
-#### Install NATS server
+### Install NATS server
 
 NATS is a powerful, cloud native message broker that aims to provide a universal communications substrate across all kinds of workloads. NATS is such a resilient, fast, small, flexible tool that it is part of the core infrastructure requirements of the wasmCloud host. For information on how to install and start the NATS server, please check the [NATS Documentation](https://docs.nats.io/nats-server/installation). Note that we require a version of NATS new enough to contain the embedded _JetStream_ functionality.
 
-Installing NATS is quick and easy. Once it's installed, run it with JetStream enabled:
+Installing NATS is quick and easy. Once it's installed, run it with JetStream enabled (you'll know you did it correctly when you see some sweet terminal ASCII art):
 
-```bash
+```plain
 nats-server --jetstream
+...
+... Starting JetStream
+...     _ ___ _____ ___ _____ ___ ___   _   __  __
+...  _ | | __|_   _/ __|_   _| _ \ __| /_\ |  \/  |
+... | || | _|  | | \__ \ | | |   / _| / _ \| |\/| |
+...  \__/|___| |_| |___/ |_| |_|_\___/_/ \_\_|  |_|
+...
 ```
 
-#### Install and start the wasmCloud host runtime
+### Install and start the wasmCloud host runtime
 
-Before you start the wasmCloud host runtime, NATS should already be running.
+The preferred way to install the wasmCloud host runtime is to download the latest [release](https://github.com/wasmCloud/wasmcloud-otp/releases). Follow the instructions below for your platform to download and extract wasmCloud.
 
-The preferred way to install the wasmCloud host runtime is to download the latest [release](https://github.com/wasmCloud/wasmcloud-otp/releases). Download the `.tar.gz` file into a directory where you want to install the server.
 
-If you are on a Mac, you'll need to run one more command before extracting the release. This command makes it so Gatekeeper will not quarantine parts of the host when you run it:
+{{% tabs %}}
+{{% tab "x86_64 Linux" %}}
 
 ```bash
+wget https://github.com/wasmCloud/wasmcloud-otp/releases/download/v0.54.6/x86_64-linux.tar.gz
+mkdir -p wasmcloud
+tar -xvf x86_64-linux.tar.gz -C wasmcloud
+```
+
+{{% /tab %}}
+{{% tab "arm64 Linux" %}}
+
+```bash
+wget https://github.com/wasmCloud/wasmcloud-otp/releases/download/v0.54.6/aarch64-linux.tar.gz
+mkdir -p wasmcloud
+tar -xvf aarch64-linux.tar.gz -C wasmcloud
+```
+
+{{% /tab %}}
+{{% tab "Intel Mac" %}}
+
+```bash
+wget https://github.com/wasmCloud/wasmcloud-otp/releases/download/v0.54.6/x86_64-macos.tar.gz
+mkdir -p wasmcloud
+# This command makes it so the MacOS Gatekeeper will not quarantine parts of the host when you run it:
 sudo xattr -d com.apple.quarantine x86_64-macos.tar.gz
+tar -xvf x86_64-macos.tar.gz -C wasmcloud
 ```
 
-Once you have downloaded the release (and run the above command if on a Mac), extract the release using the following command: (replace _ARCH_ with your architecture, and _OS_ with your operating system)
+{{% /tab %}}
+{{% tab "M1 Mac" %}}
 
 ```bash
-tar xzf ARCH-OS.tar.gz
+wget https://github.com/wasmCloud/wasmcloud-otp/releases/download/v0.54.6/aarch64-macos.tar.gz
+mkdir -p wasmcloud
+# This command makes it so the MacOS Gatekeeper will not quarantine parts of the host when you run it:
+sudo xattr -d com.apple.quarantine aarch64-macos.tar.gz
+tar -xvf aarch64-macos.tar.gz -C wasmcloud
 ```
 
-After extracting from the tar file, the host is fully installed, and the tar file can be deleted.
+{{% /tab %}}
+{{% tab "Windows" %}}
 
-There are a variety of ways to run the host. To view the command-line options, type `bin/wasmcloud_host`. The quickest way to start the host, so you can move on to [getting started](/overview/getting-started/), is the first option below:
+```powershell
+wget https://github.com/wasmCloud/wasmcloud-otp/releases/download/v0.54.6/x86_64-windows.tar.gz
+mkdir wasmcloud
+tar -xvf x86_64-windows.tar.gz -C wasmcloud
+```
 
-- To start the host running in the current terminal (The host continues running until you ctrl-c or close the terminal window)
+{{% /tab %}}
+{{% /tabs %}}
 
-  ```bash
-  bin/wasmcloud_host foreground
-  ```
+After extracting from the tar file, the host is fully installed, and the tar file can be deleted. If you haven't already, run NATS with Jetstream following the instructions [above](#install-nats-server).
 
-- Alternately, you can start it in the background with
-
-  ```bash
-  bin/wasmcloud_host start
-  ```
-
-  and stop it with `bin/wasmcloud_host stop`. You can view the logs with
-
-  ```bash
-  tail var/log/erlang.log.1
-  ```
-
-- If you're already familiar with Elixir and **iex**, Elixir's interactive shell, and want to dive into the host's internals, execute Elixir statements, and set breakpoints, start the host with
-
-  ```bash
-  bin/wasmcloud_host console
-  ```
-
-Once the wasmCloud host has started, go ahead to [Getting started](/overview/getting-started/).
+There are a variety of ways to run the host that are described in more detail in [Running the Host](/reference/host-runtime/running). For now, go ahead and `cd wasmcloud` to get into the correct directory and then run:
+```bash
+bin/wasmcloud_host foreground
+```
+This will start the host with attached logs and can be exited at any time by doing `ctrl-c`. Now, you're ready to proceed onto [Getting started](/overview/getting-started/).
 
 #### Install from source
-
 The [wasmCloud OTP host runtime](https://github.com/wasmCloud/wasmcloud-otp) and [wash](https://github.com/wasmcloud/wash) repositories are open source on GitHub. Both of these repositories can be cloned and built locally directly. Consult the README file in the respective repository for prerequisites and instructions for compiling and running.
 
 ### Stopping the wasmCloud Host Runtime

--- a/content/overview/installation/install-with-docker.md
+++ b/content/overview/installation/install-with-docker.md
@@ -1,5 +1,5 @@
 ---
-title: "Install with docker"
+title: "Install with Docker"
 date: 2018-12-29T11:02:05+06:00
 weight: 1
 draft: false

--- a/content/reference/host-runtime/running.md
+++ b/content/reference/host-runtime/running.md
@@ -1,0 +1,75 @@
+---
+title: "Running the Host"
+date: 2018-12-29T11:02:05+06:00
+weight: 11
+draft: false
+---
+
+The wasmCloud host runtime is an [Elixir distillery release](https://elixirschool.com/en/lessons/misc/distillery#what-is-a-release-0) that includes various scripts for running and managing an application. By running `bin/wasmcloud_host`, you'll see a variety of commands and options:
+```plain
+./bin/wasmcloud_host
+USAGE
+  wasmcloud_host <task> [options] [args..]
+
+COMMANDS
+
+  start                Start wasmcloud_host as a daemon
+  start_boot <file>    Start wasmcloud_host as a daemon, but supply a custom .boot file
+  foreground           Start wasmcloud_host in the foreground
+  console              Start wasmcloud_host with a console attached
+  console_clean        Start a console with code paths set but no apps loaded/started
+  console_boot <file>  Start wasmcloud_host with a console attached, but supply a custom .boot file
+  stop                 Stop the wasmcloud_host daemon
+  restart              Restart the wasmcloud_host daemon without shutting down the VM
+  reboot               Restart the wasmcloud_host daemon
+  upgrade <version>    Upgrade wasmcloud_host to <version>
+  downgrade <version>  Downgrade wasmcloud_host to <version>
+  attach               Attach the current TTY to wasmcloud_host's console
+  remote_console       Remote shell to wasmcloud_host's console
+  reload_config        Reload the current system's configuration from disk
+  pid                  Get the pid of the running wasmcloud_host instance
+  ping                 Checks if wasmcloud_host is running, pong is returned if successful
+  pingpeer <peer>      Check if a peer node is running, pong is returned if successful
+  escript              Execute an escript
+  rpc                  Execute Elixir code on the running node
+  eval                 Execute Elixir code locally
+  describe             Print useful information about the wasmcloud_host release
+
+No custom commands found.
+
+Use wasmcloud_host help <task> to get more information about a particular task (except custom commands)
+```
+There are a variety of commands and options to get used to here, we generally only focus on the commands that manage starting, stopping, and debugging a wasmCloud application.
+
+- To start the host running in the current terminal, which is recommended to easily view logs, you can use `foreground`
+
+  ```bash
+  bin/wasmcloud_host foreground
+  ```
+
+- Alternately, you can start it in the background as a daemon with `start`
+
+  ```bash
+  bin/wasmcloud_host start
+  ```
+
+  and stop it with
+  ```bash
+  bin/wasmcloud_host stop
+  ```
+  or restart it with
+  ```bash
+  bin/wasmcloud_host reboot
+  ```
+  
+  If you choose this option, host logs will be located under `var/log` and can be viewed with:
+
+  ```bash
+  tail var/log/erlang.log.1
+  ```
+
+- If you're already familiar with Elixir and **iex**, Elixir's interactive shell, and want to dive into the host's internals, execute Elixir statements, and set breakpoints, start the host including an interactive console with:
+
+  ```bash
+  bin/wasmcloud_host console
+  ```


### PR DESCRIPTION
Additionally, I went through and tweaked our install guide to simplify the steps, move some Docker mentions around, and edit some of the language that could be worded a bit better.

This doesn't fully integrate TinyGo into our documentation, we should add it to the `Combining standard capabilities` sections as well as showing a unit test for an actor, but this is a good start