### PR TITLE
OCI variable docs

### DIFF
--- a/content/overview/installation/_index.en.md
+++ b/content/overview/installation/_index.en.md
@@ -64,7 +64,7 @@ brew install wash
 {{% tab "Windows" %}}
 
 ```bash
-cargo install wash-cli
+choco install wash
 ```
 
 {{% /tab %}}

--- a/content/reference/host-runtime/host_configure.md
+++ b/content/reference/host-runtime/host_configure.md
@@ -49,5 +49,8 @@ These variables can be set in your terminal environment to configure a host. Aft
 | `WASMCLOUD_OCI_ALLOWED_INSECURE`<br/>The list of OCI hosts to which insecure connections are allowed. By default, no insecure connections are allowed. | `""` |
 | `WASMCLOUD_STRUCTURED_LOGGING_ENABLED`<br/> Set to `true` to enable JSON structured logging from the host runtime. | `false` |
 | `WASMCLOUD_STRUCTURED_LOG_LEVEL`<br/> When structured logging is enabled, this controls the verbosity of those logs. Choose from `error`, `warn`, `info`, and `debug` | `info` |
+| `OCI_REGISTRY`<br/> Specifies an OCI registry to use the following USER and PASSWORD variables to authenticate | `None` |
+| `OCI_REGISTRY_USER`<br/> Specifies a username to authenticate to the above OCI registry | `None` |
+| `OCI_REGISTRY_PASSWORD`<br/> Specifies a password to authenticate to the above OCI registry | `None` |
 
 


### PR DESCRIPTION
This PR adds documentation on the variables we use to configure the host OCI interactions

Depends on https://github.com/wasmCloud/wasmcloud-otp/pull/423