### PR TITLE
removed . from the valid list of call aliases

### DIFF
--- a/content/app-dev/a2a/_index.en.md
+++ b/content/app-dev/a2a/_index.en.md
@@ -11,19 +11,20 @@ The ability for one actor to call another actor is critical to being able to cre
 
 The single most important task when calling other actors is to identify the target actor. wasmCloud supports two ways of identifying another actor for invocation purposes:
 
-* Public Key (Subject)
-* Call Alias
+- Public Key (Subject)
+- Call Alias
 
 #### Public key (Subject)
 
 Every single actor _must_ have a subject, which is a 56-character public key made of up uppercase letters. These subject strings always start with the capital letter **M** (module). When actors are signed with embedded capability claims, they are always required to have a _subject_ claim. This means that invocation by public key is the **most reliable** means for locating target actors, though it can often impose some amount of friction on the part of calling actors.
 
 #### ⚠️ Caution
+
 You must be cautious when hard-coding public keys in your actors. If your software pipeline involves signing actors with _different private keys_ across different environments, then that will change the public keys of those actors and result in target actors not being found during invocations at runtime.
 
 #### Call alias
 
-One potentially appealing alternative to the guaranteed uniqueness and reliability of public keys is the use of a _call alias_. When actors are signed, they can optionally be signed with a `call_alias` claim. This alias must be an alphanumeric string that can optionally have separator/hierarchy characters like `.` or `/` or `_`, e.g. `accounting` or `accounting/invest`.
+One potentially appealing alternative to the guaranteed uniqueness and reliability of public keys is the use of a _call alias_. When actors are signed, they can optionally be signed with a `call_alias` claim. This alias must be an alphanumeric string that can optionally have separator/hierarchy characters like `/` or `_`, e.g. `accounting` or `accounting/invest`.
 
 When an actor with a call alias is started, the entire lattice in which that actor resides will be informed of the claim on this alias. If the alias is _already claimed_, then the newly started actor will _not_ be able to use it for identification purposes. This is the downside to using aliases: it is up to you to ensure that they are unique _per lattice_. They do not need to be globally unique.
 
@@ -51,4 +52,3 @@ let result = ponger.ping().await?;
 When you design your distributed application to allow actors to communicate with each other, you need some way to declare the _shape_ or _schema_ of the data they will use to communicate. This can easily be done using **smithy** models that declare only "actor receive" services. One actor can then invoke the "actor receive" function on another actor, enabling RPC between actors.
 
 For an overview of the steps required to compile and use an interface, take a look at [actor interfaces](/app-dev/create-provider/new-interface). For more in-depth information for creating your own interface, look at [Interfaces](/interfaces/).
-


### PR DESCRIPTION
Fixes https://github.com/wasmCloud/wasmcloud-otp/issues/488

Great point-out from @Taction that `.` is not a valid call alias character